### PR TITLE
Allow watching html elements

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -6,6 +6,12 @@
     "watchURLs": [
         "http://www.tsukuba.ac.jp/"
     ],
+    "watchTargets": [
+      {
+        "url": "https://www.coins.tsukuba.ac.jp/",
+        "selector": "#content"
+      }
+    ],
     "discord": {
         "token": "write your token here",
         "channels": [

--- a/index.ts
+++ b/index.ts
@@ -55,16 +55,18 @@ async function main(): Promise<void> {
     config.watchInterval.value,
     config.watchInterval.unit as moment.unitOfTime.Base,
   )
-  const watcher = new Watcher(config.watchURLs, duration)
+  const urlTargets = config.watchURLs.map((url: string) => ({ url: url }))
+  const targets = urlTargets.concat(config.watchTargets)
+  const watcher = new Watcher(targets, duration)
   watcher.onDiff = (diff): void => {
-    console.debug(`diff found: ${moment().toString()} at ${diff.url}`)
+    console.debug(`diff found: ${moment().toString()} at ${diff.target.url}`)
     console.debug(diff.d)
     const message = `更新が検出されました！${moment().format(
       'YYYY-MM-DD HH:mm:ss',
-    )}\n${diff.url}`
+    )}\n${diff.target.url}`
     const content = `更新が検出されました！${moment().format(
       'YYYY-MM-DD HH:mm:ss',
-    )}\`\`\`${diff.d}\`\`\`\n${diff.url}`
+    )}\`\`\`${diff.d}\`\`\`\n${diff.target.url}`
     if (content.length > config.discord.threshold) {
       const readable = new Readable()
       readable.push(diff.d)

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "diff": "^4.0.2",
     "discord.js": "^12.0.2",
+    "jsdom": "^16.2.2",
     "moment": "^2.24.0",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@types/diff": "^4.0.2",
+    "@types/jsdom": "^16.2.0",
     "@types/node": "^12.12.31",
     "@types/node-fetch": "^2.5.5",
     "@types/ws": "^7.2.3",


### PR DESCRIPTION
ページ内の特定要素の変更のみを監視できるようにしました。
これにより、ページ内のサイドバーやヘッダー等の共通部分の変更や、 CSRF トークンが含まれておりリクエストするたびに変化する部分については監視せず、メインのコンテンツのみ監視することができるようになります。

互換性のために `watchTargets` は指定しなくても動作するようにしています。その際に TypeScript が JSON から自動的に型情報を生成するとエラーになってしまう箇所があったので、 interface を定義して使用するようにしました (3b493af84fdb442ba4cf253de8a6b62e2292507a の変更)
TypeScript よくわかってないので、他にもっと良い方法があれば教えていただきたいです。